### PR TITLE
Context fixes

### DIFF
--- a/demo/types.go
+++ b/demo/types.go
@@ -1,7 +1,6 @@
 package demo
 
 import (
-	"context"
 	"errors"
 
 	"github.com/jpincas/gouuidv6"
@@ -65,7 +64,7 @@ func (o *Order) PostSave() {
 	o.OrderSaved = true
 }
 
-func (o *Order) PostGet(ctx context.Context) {
+func (o *Order) PostGet(ctx map[string]interface{}) {
 	o.OrderRetrieved = true
 }
 

--- a/tormentadb/get.go
+++ b/tormentadb/get.go
@@ -16,10 +16,10 @@ const (
 // Get retrieves an entity, either according to the ID set on the entity,
 // or using a separately specified ID (optional)
 func (db DB) Get(entity Tormentable, ids ...gouuidv6.UUID) (bool, int, error) {
-	return db.get(entity, ids...)
+	return db.get(entity, context.TODO(), ids...)
 }
 
-func (db DB) get(entity Tormentable, ids ...gouuidv6.UUID) (bool, int, error) {
+func (db DB) get(entity Tormentable, ctx context.Context, ids ...gouuidv6.UUID) (bool, int, error) {
 	// start the timer
 	t0 := time.Now()
 
@@ -81,7 +81,7 @@ func (db DB) get(entity Tormentable, ids ...gouuidv6.UUID) (bool, int, error) {
 	entity.GetCreated()
 
 	// Run the 'postGet' trigger
-	entity.PostGet(context.TODO())
+	entity.PostGet(ctx)
 
 	return true, timerMiliseconds(t0), nil
 }

--- a/tormentadb/get.go
+++ b/tormentadb/get.go
@@ -19,6 +19,14 @@ func (db DB) Get(entity Tormentable, ids ...gouuidv6.UUID) (bool, int, error) {
 	return db.get(entity, context.TODO(), ids...)
 }
 
+// Get retrieves an entity, either according to the ID set on the entity,
+// or using a separately specified ID (optional), this is the same as the above 'Get'
+// function but allows the passing of a non-empty context.
+func (db DB) GetWithContext(entity Tormentable, ctx context.Context, ids ...gouuidv6.UUID) (bool, int, error) {
+	return db.get(entity, ctx, ids...)
+}
+
+
 func (db DB) get(entity Tormentable, ctx context.Context, ids ...gouuidv6.UUID) (bool, int, error) {
 	// start the timer
 	t0 := time.Now()

--- a/tormentadb/get.go
+++ b/tormentadb/get.go
@@ -1,7 +1,6 @@
 package tormentadb
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -16,18 +15,18 @@ const (
 // Get retrieves an entity, either according to the ID set on the entity,
 // or using a separately specified ID (optional)
 func (db DB) Get(entity Tormentable, ids ...gouuidv6.UUID) (bool, int, error) {
-	return db.get(entity, context.TODO(), ids...)
+	return db.get(entity, make(map[string]interface{}), ids...)
 }
 
 // Get retrieves an entity, either according to the ID set on the entity,
 // or using a separately specified ID (optional), this is the same as the above 'Get'
 // function but allows the passing of a non-empty context.
-func (db DB) GetWithContext(entity Tormentable, ctx context.Context, ids ...gouuidv6.UUID) (bool, int, error) {
+func (db DB) GetWithContext(entity Tormentable, ctx map[string]interface{}, ids ...gouuidv6.UUID) (bool, int, error) {
 	return db.get(entity, ctx, ids...)
 }
 
 
-func (db DB) get(entity Tormentable, ctx context.Context, ids ...gouuidv6.UUID) (bool, int, error) {
+func (db DB) get(entity Tormentable, ctx map[string]interface{}, ids ...gouuidv6.UUID) (bool, int, error) {
 	// start the timer
 	t0 := time.Now()
 
@@ -74,7 +73,7 @@ func (db DB) get(entity Tormentable, ctx context.Context, ids ...gouuidv6.UUID) 
 		// Post Get trigger
 		// This seems to be a duplicate action
 		// so commenting for now
-		// entity.PostGet(context.TODO())
+		// entity.PostGet(ctx)
 
 		return nil
 	})

--- a/tormentadb/model.go
+++ b/tormentadb/model.go
@@ -1,7 +1,6 @@
 package tormentadb
 
 import (
-	"context"
 	"time"
 
 	"github.com/jpincas/gouuidv6"
@@ -14,7 +13,7 @@ type Tormentable interface {
 	UnmarshalMsg([]byte) ([]byte, error)
 	PreSave() error
 	PostSave()
-	PostGet(ctx context.Context)
+	PostGet(ctx map[string]interface{})
 	GetCreated() time.Time
 	SetID(gouuidv6.UUID)
 }
@@ -42,7 +41,7 @@ func (m Model) PreSave() error {
 
 func (m Model) PostSave() {}
 
-func (m Model) PostGet(ctx context.Context) {}
+func (m Model) PostGet(ctx map[string]interface{}) {}
 
 func (m *Model) SetID(id gouuidv6.UUID) {
 	m.ID = id

--- a/tormentadb/query.go
+++ b/tormentadb/query.go
@@ -307,7 +307,7 @@ func (q *Query) fetchIndexedRecord(item *badger.Item) error {
 	}
 
 	// Get the record
-	ok, _, err := q.db.Get(entity, key)
+	ok, _, err := q.db.get(entity, q.ctx, key)
 	if err != nil {
 		return err
 	}

--- a/tormentadb/query.go
+++ b/tormentadb/query.go
@@ -6,8 +6,6 @@ import (
 	"reflect"
 	"time"
 
-	"context"
-
 	"github.com/dgraph-io/badger"
 	"github.com/jpincas/gouuidv6"
 )
@@ -75,7 +73,7 @@ type Query struct {
 	// Is already prepared?
 	isReversePrepared bool
 
-	ctx context.Context
+	ctx map[string]interface{}
 }
 
 func (db DB) newQuery(target interface{}, first bool) *Query {
@@ -100,7 +98,7 @@ func (db DB) newQuery(target interface{}, first bool) *Query {
 	}
 
 	// Start with blank context
-	q.ctx = context.TODO()
+	q.ctx = make(map[string]interface{})
 
 	return q
 }

--- a/tormentadb/query_context_test.go
+++ b/tormentadb/query_context_test.go
@@ -23,6 +23,9 @@ func Test_Context(t *testing.T) {
 }
 
 
+// Essentially the same test as above but on an indexed match query, this failed previously because an indexed
+// search used the Public 'query.Get' function which did not take a context as a parameter and therefore simply
+// passes the empty context to the PostGet trigger.
 func Test_Context_Match(t *testing.T) {
 	db, _ := tormenta.OpenTest("data/tests")
 	defer db.Close()

--- a/tormentadb/query_context_test.go
+++ b/tormentadb/query_context_test.go
@@ -21,3 +21,20 @@ func Test_Context(t *testing.T) {
 		t.Errorf("Context was not set correctly.  Expecting: %s; Got: %s", sessionID, entity.TriggerString)
 	}
 }
+
+
+func Test_Context_Match(t *testing.T) {
+	db, _ := tormenta.OpenTest("data/tests")
+	defer db.Close()
+
+	entity := types.TestType{}
+	entity.IntField = 42
+	db.Save(&entity)
+
+	sessionID := "session1234"
+
+	db.First(&entity).SetContext("sessionid", sessionID).Match("IntField", 42).Run()
+	if entity.TriggerString != sessionID {
+		t.Errorf("Context was not set correctly.  Expecting: %s; Got: %s", sessionID, entity.TriggerString)
+	}
+}

--- a/tormentadb/query_context_test.go
+++ b/tormentadb/query_context_test.go
@@ -1,7 +1,6 @@
 package tormentadb_test
 
 import (
-	"context"
 	"testing"
 
 	tormenta "github.com/jpincas/tormenta/tormentadb"
@@ -55,7 +54,8 @@ func Test_Context_Get(t *testing.T) {
 	entity.ID = savedEntity.ID
 
 	sessionID := "session1234"
-	ctx := context.WithValue(context.TODO(), "sessionid", sessionID)
+	ctx := make(map[string]interface{})
+	ctx["sessionid"] =  sessionID
 
 	db.GetWithContext(&entity, ctx)
 	if entity.TriggerString != sessionID {

--- a/tormentadb/query_context_test.go
+++ b/tormentadb/query_context_test.go
@@ -1,6 +1,7 @@
 package tormentadb_test
 
 import (
+	"context"
 	"testing"
 
 	tormenta "github.com/jpincas/tormenta/tormentadb"
@@ -41,3 +42,24 @@ func Test_Context_Match(t *testing.T) {
 		t.Errorf("Context was not set correctly.  Expecting: %s; Got: %s", sessionID, entity.TriggerString)
 	}
 }
+
+
+func Test_Context_Get(t *testing.T) {
+	db, _ := tormenta.OpenTest("data/tests")
+	defer db.Close()
+
+	savedEntity := types.TestType{}
+	db.Save(&savedEntity)
+
+	entity := types.TestType{}
+	entity.ID = savedEntity.ID
+
+	sessionID := "session1234"
+	ctx := context.WithValue(context.TODO(), "sessionid", sessionID)
+
+	db.GetWithContext(&entity, ctx)
+	if entity.TriggerString != sessionID {
+		t.Errorf("Context was not set correctly.  Expecting: %s; Got: %s", sessionID, entity.TriggerString)
+	}
+}
+

--- a/tormentadb/queryapi.go
+++ b/tormentadb/queryapi.go
@@ -1,7 +1,6 @@
 package tormentadb
 
 import (
-	"context"
 	"errors"
 	"strings"
 	"time"
@@ -88,8 +87,8 @@ func (q *Query) Reverse() *Query {
 	return q
 }
 
-func (q *Query) SetContext(key, val interface{}) *Query {
-	q.ctx = context.WithValue(q.ctx, key, val)
+func (q *Query) SetContext(key string, val interface{}) *Query {
+	q.ctx[key] = val
 	return q
 }
 

--- a/tormentadb/types/types.go
+++ b/tormentadb/types/types.go
@@ -1,8 +1,6 @@
 package types
 
 import (
-	"context"
-
 	tormenta "github.com/jpincas/tormenta/tormentadb"
 )
 
@@ -56,6 +54,6 @@ type TestType struct {
 	TriggerString string
 }
 
-func (t *TestType) PostGet(ctx context.Context) {
-	t.TriggerString = ctx.Value("sessionid").(string)
+func (t *TestType) PostGet(ctx map[string]interface{}) {
+	t.TriggerString = ctx["sessionid"].(string)
 }


### PR DESCRIPTION
The fix for contexts in PostGet trigger functions on indexed queries.
In addition I've switched contexts to be maps rather than 'context's because reading the documentation suggests they are not appropriate for our purposes here. In particular it is suggested that a context should not be stored in a struct nor have strings as keys, both of which we're doing.